### PR TITLE
change how we retrieve all reports

### DIFF
--- a/community_core_puller/community_core_scraper.py
+++ b/community_core_puller/community_core_scraper.py
@@ -76,7 +76,7 @@ class CommunityCoreScraper:
         report_id = next(
             (
                 category["id"]
-                for category in response.json()["Value"]
+                for category in response.json()
                 if category["name"].strip() == report_name
             ),
             None,


### PR DESCRIPTION
community core changed their api endpoint for getting report metadata so that all the report objects no longer live in the "value" key.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `get_report_id` in `community_core_scraper.py` to handle new API response format without a `"Value"` key.
> 
>   - **Behavior**:
>     - Update `get_report_id` in `community_core_scraper.py` to handle new API response format by removing the expectation of a `"Value"` key in the JSON response.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fcommunity_core_puller&utm_source=github&utm_medium=referral)<sup> for ed010495ece9d2f9cfd351eb787a94f4c32fe0c0. You can [customize](https://app.ellipsis.dev/tolemi-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->